### PR TITLE
[AMQ-9548] Add attributes to display total number of queues and topics

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/BrokerView.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/BrokerView.java
@@ -287,7 +287,7 @@ public class BrokerView implements BrokerViewMBean {
 
     @Override
     public int getTotalManagedTopicsCount() {
-        return safeGetBroker().getTopicViews().size();
+        return safeGetBroker().getTopicsNonSuppressed().length;
     }
 
     @Override
@@ -307,7 +307,7 @@ public class BrokerView implements BrokerViewMBean {
 
     @Override
     public int getTotalManagedQueuesCount() {
-        return safeGetBroker().getQueueViews().size();
+        return safeGetBroker().getQueuesNonSuppressed().length;
     }
 
     @Override

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/BrokerView.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/BrokerView.java
@@ -282,7 +282,17 @@ public class BrokerView implements BrokerViewMBean {
 
     @Override
     public int getTotalTopicsCount() {
-        return getTopics().length;
+        return safeGetBroker().getTopicRegion().getDestinationMap().size();
+    }
+
+    @Override
+    public int getTotalNonSuppressedTopicsCount() {
+        return safeGetBroker().getTopicViews().size();
+    }
+
+    @Override
+    public int getTotalTemporaryTopicsCount() {
+        return safeGetBroker().getTempTopicRegion().getDestinationMap().size();
     }
 
     @Override
@@ -292,7 +302,17 @@ public class BrokerView implements BrokerViewMBean {
 
     @Override
     public int getTotalQueuesCount() {
-        return getQueues().length;
+        return safeGetBroker().getQueueRegion().getDestinationMap().size();
+    }
+
+    @Override
+    public int getTotalNonSuppressedQueuesCount() {
+        return safeGetBroker().getQueueViews().size();
+    }
+
+    @Override
+    public int getTotalTemporaryQueuesCount() {
+        return safeGetBroker().getTempQueueRegion().getDestinationMap().size();
     }
 
     @Override

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/BrokerView.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/BrokerView.java
@@ -281,8 +281,18 @@ public class BrokerView implements BrokerViewMBean {
     }
 
     @Override
+    public int getTotalTopicsCount() {
+        return getTopics().length;
+    }
+
+    @Override
     public ObjectName[] getQueues() {
         return safeGetBroker().getQueuesNonSuppressed();
+    }
+
+    @Override
+    public int getTotalQueuesCount() {
+        return getQueues().length;
     }
 
     @Override

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/BrokerView.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/BrokerView.java
@@ -286,7 +286,7 @@ public class BrokerView implements BrokerViewMBean {
     }
 
     @Override
-    public int getTotalNonSuppressedTopicsCount() {
+    public int getTotalManagedTopicsCount() {
         return safeGetBroker().getTopicViews().size();
     }
 
@@ -306,7 +306,7 @@ public class BrokerView implements BrokerViewMBean {
     }
 
     @Override
-    public int getTotalNonSuppressedQueuesCount() {
+    public int getTotalManagedQueuesCount() {
         return safeGetBroker().getQueueViews().size();
     }
 

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/BrokerViewMBean.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/BrokerViewMBean.java
@@ -179,8 +179,16 @@ public interface BrokerViewMBean extends Service {
     @MBeanInfo("Topics (broadcasted 'queues'); generally system information.")
     ObjectName[] getTopics();
 
+    @MBeanInfo("Total number of topics")
+    int getTotalTopicsCount();
+
+
     @MBeanInfo("Standard Queues containing AIE messages.")
     ObjectName[] getQueues();
+
+    @MBeanInfo("Total number of queues")
+    int getTotalQueuesCount();
+
 
     /**
      * Queue Query API, take a look at {@link DestinationsViewFilter} for more information

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/BrokerViewMBean.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/BrokerViewMBean.java
@@ -183,7 +183,7 @@ public interface BrokerViewMBean extends Service {
     int getTotalTopicsCount();
 
     @MBeanInfo("Total number of non suppressed topics")
-    int getTotalNonSuppressedTopicsCount();
+    int getTotalManagedTopicsCount();
 
     @MBeanInfo("Total number of temporary topics")
     int getTotalTemporaryTopicsCount();
@@ -195,7 +195,7 @@ public interface BrokerViewMBean extends Service {
     int getTotalQueuesCount();
 
     @MBeanInfo("Total number of non suppressed queues")
-    int getTotalNonSuppressedQueuesCount();
+    int getTotalManagedQueuesCount();
 
     @MBeanInfo("Total number of temporary queues")
     int getTotalTemporaryQueuesCount();

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/BrokerViewMBean.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/BrokerViewMBean.java
@@ -182,6 +182,11 @@ public interface BrokerViewMBean extends Service {
     @MBeanInfo("Total number of topics")
     int getTotalTopicsCount();
 
+    @MBeanInfo("Total number of non suppressed topics")
+    int getTotalNonSuppressedTopicsCount();
+
+    @MBeanInfo("Total number of temporary topics")
+    int getTotalTemporaryTopicsCount();
 
     @MBeanInfo("Standard Queues containing AIE messages.")
     ObjectName[] getQueues();
@@ -189,6 +194,11 @@ public interface BrokerViewMBean extends Service {
     @MBeanInfo("Total number of queues")
     int getTotalQueuesCount();
 
+    @MBeanInfo("Total number of non suppressed queues")
+    int getTotalNonSuppressedQueuesCount();
+
+    @MBeanInfo("Total number of temporary queues")
+    int getTotalTemporaryQueuesCount();
 
     /**
      * Queue Query API, take a look at {@link DestinationsViewFilter} for more information

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/broker/jmx/BrokerViewTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/broker/jmx/BrokerViewTest.java
@@ -17,47 +17,52 @@
 package org.apache.activemq.broker.jmx;
 
 import jakarta.jms.*;
-import jakarta.jms.Connection;
-import org.apache.activemq.*;
-import org.apache.activemq.broker.*;
-import org.apache.activemq.util.*;
-import org.junit.*;
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.broker.BrokerRegistry;
+import org.apache.activemq.broker.BrokerService;
+import org.apache.activemq.util.Wait;
+import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
 
 public class BrokerViewTest {
-    protected BrokerService brokerService;
-    protected ActiveMQConnectionFactory factory;
-    protected Connection producerConnection;
-
-    protected Session producerSession;
-    protected MessageConsumer consumer;
-    protected MessageProducer producer;
-    protected Queue queue;
-
-    @Before
-    public void setUp() throws Exception {
-        brokerService = new BrokerService();
+    @Test(timeout=120000)
+    public void testBrokerViewRetrieveQueuesAndTopicsCount() throws Exception {
+        BrokerService brokerService = new BrokerService();
         brokerService.setPersistent(false);
         brokerService.start();
 
-        factory =  new ActiveMQConnectionFactory(BrokerRegistry.getInstance().findFirst().getVmConnectorURI());
-        producerConnection = factory.createConnection();
+        ActiveMQConnectionFactory factory =  new ActiveMQConnectionFactory(BrokerRegistry.getInstance().findFirst().getVmConnectorURI());
+        Connection producerConnection = factory.createConnection();
         producerConnection.start();
-        producerSession = producerConnection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+        // Create non-suppressed queue
+        Session producerSession = producerConnection.createSession(false, Session.AUTO_ACKNOWLEDGE);
         Queue queue = producerSession.createQueue("testQueue");
-        producer = producerSession.createProducer(queue);
+        MessageProducer producer = producerSession.createProducer(queue);
         producer.send(producerSession.createTextMessage("testMessage"));
-    }
+        // Create temporary queue
+        Session tempProducerSession = producerConnection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+        Queue tempQueue = tempProducerSession.createTemporaryQueue();
+        MessageProducer tempProducer = tempProducerSession.createProducer(tempQueue);
+        tempProducer.send(tempProducerSession.createTextMessage("testMessage"));
+        // Create non-suppressed topic
+        Session topicProducerSession = producerConnection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+        Topic topic = topicProducerSession.createTopic("testTopic");
+        MessageProducer topicProducer = topicProducerSession.createProducer(topic);
+        topicProducer.send(topicProducerSession.createTextMessage("testMessage"));
+        // Create temporary topic
+        Session tempTopicProducerSession = producerConnection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+        Topic tempTopic = tempTopicProducerSession.createTemporaryTopic();
+        MessageProducer tempTopicProducer = tempTopicProducerSession.createProducer(tempTopic);
+        tempTopicProducer.send(tempTopicProducerSession.createTextMessage("testMessage"));
 
-    @Test(timeout=120000)
-    public void testBrokerViewRetrieveTotalQueuesAndTopicsCount() throws Exception {
         assertTrue(Wait.waitFor(() -> (brokerService.getAdminView()) != null));
-
         final BrokerView view = brokerService.getAdminView();
-        // The total number of advisory topics
-        assert(view.getTotalTopicsCount() == 4);
-        // The queue created in setup
+        assert(view.getTotalTopicsCount() == 11); // Including advisory topics
+        assert(view.getTotalNonSuppressedTopicsCount() == 11);
+        assert(view.getTotalTemporaryTopicsCount() == 1);
         assert(view.getTotalQueuesCount() == 1);
+        assert(view.getTotalNonSuppressedQueuesCount() == 1);
+        assert(view.getTotalTemporaryQueuesCount() == 1);
     }
 }

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/broker/jmx/BrokerViewTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/broker/jmx/BrokerViewTest.java
@@ -23,7 +23,9 @@ import org.apache.activemq.broker.BrokerService;
 import org.apache.activemq.util.Wait;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
 
 public class BrokerViewTest {
     @Test(timeout=120000)
@@ -45,6 +47,10 @@ public class BrokerViewTest {
         Queue tempQueue = tempProducerSession.createTemporaryQueue();
         MessageProducer tempProducer = tempProducerSession.createProducer(tempQueue);
         tempProducer.send(tempProducerSession.createTextMessage("testMessage"));
+        Session tempProducerSession2 = producerConnection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+        Queue tempQueue2 = tempProducerSession2.createTemporaryQueue();
+        MessageProducer tempProducer2 = tempProducerSession2.createProducer(tempQueue2);
+        tempProducer2.send(tempProducerSession2.createTextMessage("testMessage"));
         // Create non-suppressed topic
         Session topicProducerSession = producerConnection.createSession(false, Session.AUTO_ACKNOWLEDGE);
         Topic topic = topicProducerSession.createTopic("testTopic");
@@ -58,11 +64,11 @@ public class BrokerViewTest {
 
         assertTrue(Wait.waitFor(() -> (brokerService.getAdminView()) != null));
         final BrokerView view = brokerService.getAdminView();
-        assert(view.getTotalTopicsCount() == 11); // Including advisory topics
-        assert(view.getTotalNonSuppressedTopicsCount() == 11);
-        assert(view.getTotalTemporaryTopicsCount() == 1);
-        assert(view.getTotalQueuesCount() == 1);
-        assert(view.getTotalNonSuppressedQueuesCount() == 1);
-        assert(view.getTotalTemporaryQueuesCount() == 1);
+        assertEquals(view.getTotalTopicsCount(), 12);
+        assertEquals(view.getTotalNonSuppressedTopicsCount(), 12);
+        assertEquals(view.getTotalTemporaryTopicsCount(), 1);
+        assertEquals(view.getTotalQueuesCount(), 1);
+        assertEquals(view.getTotalNonSuppressedQueuesCount(), 1);
+        assertEquals(view.getTotalTemporaryQueuesCount(), 2);
     }
 }

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/broker/jmx/BrokerViewTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/broker/jmx/BrokerViewTest.java
@@ -32,6 +32,12 @@ public class BrokerViewTest {
     public void testBrokerViewRetrieveQueuesAndTopicsCount() throws Exception {
         BrokerService brokerService = new BrokerService();
         brokerService.setPersistent(false);
+
+        // Create and configure ManagementContext with suppressed destinations
+        ManagementContext managementContext = new ManagementContext();
+        managementContext.setCreateConnector(false);
+        managementContext.setSuppressMBean("destinationType=Queue,destinationType=Topic");
+        brokerService.setManagementContext(managementContext);
         brokerService.start();
 
         ActiveMQConnectionFactory factory =  new ActiveMQConnectionFactory(BrokerRegistry.getInstance().findFirst().getVmConnectorURI());
@@ -65,10 +71,10 @@ public class BrokerViewTest {
         assertTrue(Wait.waitFor(() -> (brokerService.getAdminView()) != null));
         final BrokerView view = brokerService.getAdminView();
         assertEquals(view.getTotalTopicsCount(), 12);
-        assertEquals(view.getTotalNonSuppressedTopicsCount(), 12);
+        assertEquals(view.getTotalManagedTopicsCount(), 12);
         assertEquals(view.getTotalTemporaryTopicsCount(), 1);
         assertEquals(view.getTotalQueuesCount(), 1);
-        assertEquals(view.getTotalNonSuppressedQueuesCount(), 1);
+        assertEquals(view.getTotalManagedQueuesCount(), 1);
         assertEquals(view.getTotalTemporaryQueuesCount(), 2);
     }
 }

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/broker/jmx/BrokerViewTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/broker/jmx/BrokerViewTest.java
@@ -36,7 +36,7 @@ public class BrokerViewTest {
         // Create and configure ManagementContext with suppressed destinations
         ManagementContext managementContext = new ManagementContext();
         managementContext.setCreateConnector(false);
-        managementContext.setSuppressMBean("destinationType=Queue,destinationType=Topic");
+        managementContext.setSuppressMBean("endpoint=dynamicProducer,destinationName=suppressedQueue,destinationName=suppressedTopic");
         brokerService.setManagementContext(managementContext);
         brokerService.start();
 
@@ -48,6 +48,10 @@ public class BrokerViewTest {
         Queue queue = producerSession.createQueue("testQueue");
         MessageProducer producer = producerSession.createProducer(queue);
         producer.send(producerSession.createTextMessage("testMessage"));
+        // Create suppressed queue
+        Queue suppressedQueue = producerSession.createQueue("suppressedQueue");
+        MessageProducer suppressedProducer = producerSession.createProducer(suppressedQueue);
+        suppressedProducer.send(producerSession.createTextMessage("testMessage"));
         // Create temporary queue
         Session tempProducerSession = producerConnection.createSession(false, Session.AUTO_ACKNOWLEDGE);
         Queue tempQueue = tempProducerSession.createTemporaryQueue();
@@ -62,6 +66,11 @@ public class BrokerViewTest {
         Topic topic = topicProducerSession.createTopic("testTopic");
         MessageProducer topicProducer = topicProducerSession.createProducer(topic);
         topicProducer.send(topicProducerSession.createTextMessage("testMessage"));
+        // Create suppressed topic
+        Session suppressedTopicProducerSession = producerConnection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+        Topic suppressedTopic = suppressedTopicProducerSession.createTopic("suppressedTopic");
+        MessageProducer suppressedTopicProducer = topicProducerSession.createProducer(suppressedTopic);
+        topicProducer.send(suppressedTopicProducerSession.createTextMessage("testMessage"));
         // Create temporary topic
         Session tempTopicProducerSession = producerConnection.createSession(false, Session.AUTO_ACKNOWLEDGE);
         Topic tempTopic = tempTopicProducerSession.createTemporaryTopic();
@@ -70,11 +79,12 @@ public class BrokerViewTest {
 
         assertTrue(Wait.waitFor(() -> (brokerService.getAdminView()) != null));
         final BrokerView view = brokerService.getAdminView();
-        assertEquals(view.getTotalTopicsCount(), 12);
-        assertEquals(view.getTotalManagedTopicsCount(), 12);
-        assertEquals(view.getTotalTemporaryTopicsCount(), 1);
-        assertEquals(view.getTotalQueuesCount(), 1);
-        assertEquals(view.getTotalManagedQueuesCount(), 1);
+        assertEquals(15, view.getTotalTopicsCount());
+        assertEquals(14, view.getTotalManagedTopicsCount());
+        assertEquals(1, view.getTotalTemporaryTopicsCount());
+        assertEquals(1, view.getQueues().length);
+        assertEquals(2, view.getTotalQueuesCount());
+        assertEquals(1, view.getTotalManagedQueuesCount());
         assertEquals(view.getTotalTemporaryQueuesCount(), 2);
     }
 }

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/broker/jmx/BrokerViewTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/broker/jmx/BrokerViewTest.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.broker.jmx;
+
+import jakarta.jms.*;
+import jakarta.jms.Connection;
+import org.apache.activemq.*;
+import org.apache.activemq.broker.*;
+import org.apache.activemq.util.*;
+import org.junit.*;
+
+import static org.junit.Assert.assertTrue;
+
+public class BrokerViewTest {
+    protected BrokerService brokerService;
+    protected ActiveMQConnectionFactory factory;
+    protected Connection producerConnection;
+
+    protected Session producerSession;
+    protected MessageConsumer consumer;
+    protected MessageProducer producer;
+    protected Queue queue;
+
+    @Before
+    public void setUp() throws Exception {
+        brokerService = new BrokerService();
+        brokerService.setPersistent(false);
+        brokerService.start();
+
+        factory =  new ActiveMQConnectionFactory(BrokerRegistry.getInstance().findFirst().getVmConnectorURI());
+        producerConnection = factory.createConnection();
+        producerConnection.start();
+        producerSession = producerConnection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+        Queue queue = producerSession.createQueue("testQueue");
+        producer = producerSession.createProducer(queue);
+        producer.send(producerSession.createTextMessage("testMessage"));
+    }
+
+    @Test(timeout=120000)
+    public void testBrokerViewRetrieveTotalQueuesAndTopicsCount() throws Exception {
+        assertTrue(Wait.waitFor(() -> (brokerService.getAdminView()) != null));
+
+        final BrokerView view = brokerService.getAdminView();
+        // The total number of advisory topics
+        assert(view.getTotalTopicsCount() == 4);
+        // The queue created in setup
+        assert(view.getTotalQueuesCount() == 1);
+    }
+}


### PR DESCRIPTION
**What problems does this PR solve?**
Currently, to get the total number of queues and topics on the broker using JMX, one needs to query the attribute values of Queues and Topics on the broker MBean then post-process it (finding the length of returned array) to get that data. This can be resource intensive (unnecessary copy of the data) on the customer application using JMX or Jolokia if user has tens or thousands of destinations and all the user wants is the number. Hence this PR added two attributes so customer application can just query the total number without getting the list of topics and queues first. 

**Why is it beneficial to merge into ActiveMQ?**
This will be beneficial for users with high number of destinations. They can now monitor the total number of queues and topics in a more performant way. 

**How do you make sure this PR is well tested?**
- Added unit test in the PR
- Tested with Jolokia (cross-checked with the web console) [see attachment below]
- Tested with Jconsole (cross-checked with the web console) [see attachment below]

![image](https://github.com/user-attachments/assets/471039e6-7641-4fe1-9c87-34e745e6bb47)
![image](https://github.com/user-attachments/assets/5d14278b-e299-4141-8253-ac71e197a123)
![image](https://github.com/user-attachments/assets/c0571ba8-7c17-40cc-ab9c-4c2680fa105c)
