### PR TITLE
[Jakarta Messaging 3.1] Asynchronous send with CompletionListener

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/OpenTypeSupport.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/OpenTypeSupport.java
@@ -159,16 +159,21 @@ public final class OpenTypeSupport {
         public Map<String, Object> getFields(Object o) throws OpenDataException {
             ActiveMQMessage m = (ActiveMQMessage)o;
             Map<String, Object> rc = super.getFields(o);
-            rc.put("JMSCorrelationID", m.getJMSCorrelationID());
-            rc.put("JMSDestination", "" + m.getJMSDestination());
-            rc.put("JMSMessageID", m.getJMSMessageID());
-            rc.put("JMSReplyTo",toString(m.getJMSReplyTo()));
-            rc.put("JMSType", m.getJMSType());
-            rc.put("JMSDeliveryMode", m.getJMSDeliveryMode() == DeliveryMode.PERSISTENT ? "PERSISTENT" : "NON-PERSISTENT");
-            rc.put("JMSExpiration", m.getJMSExpiration());
-            rc.put("JMSPriority", m.getJMSPriority());
-            rc.put("JMSRedelivered", m.getJMSRedelivered());
-            rc.put("JMSTimestamp", new Date(m.getJMSTimestamp()));
+            try {
+                rc.put("JMSCorrelationID", m.getJMSCorrelationID());
+                rc.put("JMSDestination", "" + m.getJMSDestination());
+                rc.put("JMSMessageID", m.getJMSMessageID());
+                rc.put("JMSReplyTo",toString(m.getJMSReplyTo()));
+                rc.put("JMSType", m.getJMSType());
+                rc.put("JMSDeliveryMode", m.getJMSDeliveryMode() == DeliveryMode.PERSISTENT ? "PERSISTENT" : "NON-PERSISTENT");
+                rc.put("JMSExpiration", m.getJMSExpiration());
+                rc.put("JMSPriority", m.getJMSPriority());
+                rc.put("JMSRedelivered", m.getJMSRedelivered());
+                rc.put("JMSTimestamp", new Date(m.getJMSTimestamp()));
+            } catch (JMSException e) {
+                throw new OpenDataException(e.getMessage());
+            }
+
             rc.put(CompositeDataConstants.JMSXGROUP_ID, m.getGroupID());
             rc.put(CompositeDataConstants.JMSXGROUP_SEQ, m.getGroupSequence());
             rc.put(CompositeDataConstants.JMSXUSER_ID, m.getUserID());

--- a/activemq-client/src/main/java/org/apache/activemq/ActiveMQMessageProducer.java
+++ b/activemq-client/src/main/java/org/apache/activemq/ActiveMQMessageProducer.java
@@ -23,10 +23,10 @@ import java.util.concurrent.atomic.AtomicLong;
 import jakarta.jms.CompletionListener;
 import jakarta.jms.Destination;
 import jakarta.jms.IllegalStateException;
+import jakarta.jms.IllegalStateRuntimeException;
 import jakarta.jms.InvalidDestinationException;
 import jakarta.jms.JMSException;
 import jakarta.jms.Message;
-
 import org.apache.activemq.command.ActiveMQDestination;
 import org.apache.activemq.command.ProducerAck;
 import org.apache.activemq.command.ProducerId;
@@ -83,11 +83,13 @@ public class ActiveMQMessageProducer extends ActiveMQMessageProducerSupport impl
     private final long startTime;
     private MessageTransformer transformer;
     private MemoryUsage producerWindow;
+    private final ThreadLocal<Boolean> inCompletionListenerCallback = new ThreadLocal<>();
 
     protected ActiveMQMessageProducer(ActiveMQSession session, ProducerId producerId, ActiveMQDestination destination, int sendTimeout) throws JMSException {
         super(session);
         this.info = new ProducerInfo(producerId);
         this.info.setWindowSize(session.connection.getProducerWindowSize());
+        inCompletionListenerCallback.set(false);
         // Allows the options on the destination to configure the producerInfo
         if (destination != null && destination.getOptions() != null) {
             Map<String, Object> options = IntrospectionSupport.extractProperties(
@@ -168,6 +170,9 @@ public class ActiveMQMessageProducer extends ActiveMQMessageProducerSupport impl
      */
     @Override
     public void close() throws JMSException {
+        if (inCompletionListenerCallback.get()) {
+            throw new IllegalStateRuntimeException("Can't close message producer within CompletionListener");
+        }
         if (!closed) {
             dispose();
             this.session.asyncSendPacket(info.createRemoveCommand());
@@ -239,27 +244,88 @@ public class ActiveMQMessageProducer extends ActiveMQMessageProducerSupport impl
      */
     @Override
     public void send(Message message, CompletionListener completionListener) throws JMSException {
-        throw new UnsupportedOperationException("send(Message, CompletionListener) is not supported");
+        this.send(getDestination(),
+                message,
+                defaultDeliveryMode,
+                defaultPriority,
+                defaultTimeToLive,
+                completionListener);
     }
+
 
     @Override
     public void send(Message message, int deliveryMode, int priority, long timeToLive,
                       CompletionListener completionListener) throws JMSException {
-        throw new UnsupportedOperationException("send(Message, deliveryMode, priority, timetoLive, CompletionListener) is not supported");
+        this.send(this.getDestination(),
+                message,
+                deliveryMode,
+                priority,
+                timeToLive,
+                completionListener);
     }
 
     @Override
     public void send(Destination destination, Message message, CompletionListener completionListener) throws JMSException {
-        throw new UnsupportedOperationException("send(Destination, Message, CompletionListener) is not supported");
+        this.send(destination,
+                message,
+                defaultDeliveryMode,
+                defaultPriority,
+                defaultTimeToLive,
+                completionListener);
     }
 
     @Override
     public void send(Destination destination, Message message, int deliveryMode, int priority, long timeToLive,
                      CompletionListener completionListener) throws JMSException {
-        throw new UnsupportedOperationException("send(Destination, Message, deliveryMode, priority, timetoLive, CompletionListener) is not supported");
+        this.send(destination, message, deliveryMode, priority, timeToLive,
+                getDisableMessageID(), getDisableMessageTimestamp(), completionListener);
     }
 
-    public void send(Message message, AsyncCallback onComplete) throws JMSException {
+    public void send(Destination destination, Message message, int deliveryMode, int priority, long timeToLive,
+            boolean disableMessageID, boolean disableMessageTimestamp, CompletionListener completionListener) throws JMSException {
+        checkClosed();
+        if (destination == null) {
+            if (info.getDestination() == null) {
+                throw new UnsupportedOperationException("A destination must be specified.");
+            }
+            throw new InvalidDestinationException("Don't understand null destinations");
+        }
+
+        ActiveMQDestination dest;
+        if (destination.equals(info.getDestination())) {
+            dest = (ActiveMQDestination)destination;
+        } else if (info.getDestination() == null) {
+            dest = ActiveMQDestination.transform(destination);
+        } else {
+            throw new UnsupportedOperationException("This producer can only send messages to: " + this.info.getDestination().getPhysicalName());
+        }
+        if (dest == null) {
+            throw new JMSException("No destination specified");
+        }
+
+        if (transformer != null) {
+            Message transformedMessage = transformer.producerTransform(session, this, message);
+            if (transformedMessage != null) {
+                message = transformedMessage;
+            }
+        }
+
+        if (producerWindow != null) {
+            try {
+                producerWindow.waitForSpace();
+            } catch (InterruptedException e) {
+                throw new JMSException("Send aborted due to thread interrupt.");
+            }
+        }
+
+        this.session.send(this, dest, message, deliveryMode, priority, timeToLive, disableMessageID,
+                disableMessageTimestamp, producerWindow, sendTimeout, completionListener, inCompletionListenerCallback);
+
+        stats.onMessage();
+    }
+
+
+        public void send(Message message, AsyncCallback onComplete) throws JMSException {
         this.send(this.getDestination(),
                   message,
                   this.defaultDeliveryMode,

--- a/activemq-client/src/main/java/org/apache/activemq/ActiveMQMessageProducer.java
+++ b/activemq-client/src/main/java/org/apache/activemq/ActiveMQMessageProducer.java
@@ -170,7 +170,7 @@ public class ActiveMQMessageProducer extends ActiveMQMessageProducerSupport impl
      */
     @Override
     public void close() throws JMSException {
-        if (inCompletionListenerCallback.get()) {
+        if (inCompletionListenerCallback != null && inCompletionListenerCallback.get()) {
             throw new IllegalStateRuntimeException("Can't close message producer within CompletionListener");
         }
         if (!closed) {

--- a/activemq-client/src/main/java/org/apache/activemq/ActiveMQProducer.java
+++ b/activemq-client/src/main/java/org/apache/activemq/ActiveMQProducer.java
@@ -56,6 +56,7 @@ public class ActiveMQProducer implements JMSProducer {
 
     // Properties applied to all messages on a per-JMS producer instance basis
     private Map<String, Object> messageProperties = null;
+    private CompletionListener completionListener = null;
 
     ActiveMQProducer(ActiveMQContext activemqContext, ActiveMQMessageProducer activemqMessageProducer) {
         this.activemqContext = activemqContext;
@@ -86,8 +87,7 @@ public class ActiveMQProducer implements JMSProducer {
                     message.setObjectProperty(propertyEntry.getKey(), propertyEntry.getValue());
                 }
             }
-
-            activemqMessageProducer.send(destination, message, getDeliveryMode(), getPriority(), getTimeToLive(), getDisableMessageID(), getDisableMessageTimestamp(), null);
+            activemqMessageProducer.send(destination, message, getDeliveryMode(), getPriority(), getTimeToLive(), getDisableMessageID(), getDisableMessageTimestamp(), getAsync());
         } catch (JMSException e) {
             throw JMSExceptionSupport.convertToJMSRuntimeException(e);
         }
@@ -253,12 +253,13 @@ public class ActiveMQProducer implements JMSProducer {
 
     @Override
     public JMSProducer setAsync(CompletionListener completionListener) {
-        throw new UnsupportedOperationException("setAsync(CompletionListener) is not supported");
+        this.completionListener = completionListener;
+        return this;
     }
 
     @Override
     public CompletionListener getAsync() {
-        throw new UnsupportedOperationException("getAsync() is not supported");
+        return this.completionListener;
     }
 
     @Override

--- a/activemq-client/src/main/java/org/apache/activemq/ActiveMQSession.java
+++ b/activemq-client/src/main/java/org/apache/activemq/ActiveMQSession.java
@@ -606,7 +606,7 @@ public class ActiveMQSession implements Session, QueueSession, TopicSession, Sta
     @Override
     public void rollback() throws JMSException {
         checkClosed();
-        if (inCompletionListenerCallback.get()) {
+        if (inCompletionListenerCallback.get() != null && inCompletionListenerCallback.get()) {
             throw new IllegalStateRuntimeException("Can't rollback transacted session within CompletionListener");
         }
         if (!getTransacted()) {

--- a/activemq-client/src/main/java/org/apache/activemq/command/Message.java
+++ b/activemq-client/src/main/java/org/apache/activemq/command/Message.java
@@ -215,7 +215,7 @@ public abstract class Message extends BaseCommand implements MarshallAware, Mess
         return Collections.unmodifiableMap(properties);
     }
 
-    public void clearProperties() {
+    public void clearProperties() throws JMSException {
         marshalledProperties = null;
         properties = null;
     }

--- a/activemq-client/src/main/java/org/apache/activemq/util/CountdownLock.java
+++ b/activemq-client/src/main/java/org/apache/activemq/util/CountdownLock.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.util;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * This concurrent data structure is used when the calling thread wants to wait until a counter gets to 0 but the counter
+ * can go up and down (unlike a CountDownLatch which can only count down)
+ */
+public class CountdownLock {
+
+    final Object counterMonitor = new Object();
+    private final AtomicInteger counter = new AtomicInteger();
+
+    public void doWaitForZero() {
+        synchronized(counterMonitor){
+            try {
+                if (counter.get() > 0) {
+                    counterMonitor.wait();
+                }
+            } catch (InterruptedException e) {
+                return;
+            }
+        }
+    }
+
+    public void doDecrement() {
+        synchronized(counterMonitor){
+            if (counter.decrementAndGet() == 0) {
+                counterMonitor.notify();
+            }
+        }
+    }
+
+    public void doIncrement() {
+        synchronized(counterMonitor){
+            counter.incrementAndGet();
+        }
+    }
+}

--- a/activemq-mqtt/src/main/java/org/apache/activemq/transport/mqtt/MQTTPacketIdGenerator.java
+++ b/activemq-mqtt/src/main/java/org/apache/activemq/transport/mqtt/MQTTPacketIdGenerator.java
@@ -19,6 +19,7 @@ package org.apache.activemq.transport.mqtt;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import jakarta.jms.JMSException;
 import org.apache.activemq.Service;
 import org.apache.activemq.broker.BrokerService;
 import org.apache.activemq.command.ActiveMQMessage;
@@ -67,7 +68,7 @@ public class MQTTPacketIdGenerator extends ServiceSupport {
         return clientIdMap.remove(clientId) != null;
     }
 
-    public short setPacketId(String clientId, MQTTSubscription subscription, ActiveMQMessage message, PUBLISH publish) {
+    public short setPacketId(String clientId, MQTTSubscription subscription, ActiveMQMessage message, PUBLISH publish) throws JMSException {
         final PacketIdMaps idMaps = clientIdMap.get(clientId);
         if (idMaps == null) {
             // maybe its a cleansession=true client id, use session less message id
@@ -125,7 +126,7 @@ public class MQTTPacketIdGenerator extends ServiceSupport {
         final Map<String, Short> activemqToPacketIds = new LRUCache<String, Short>(MQTTProtocolConverter.DEFAULT_CACHE_SIZE);
         final Map<Short, String> packetIdsToActivemq = new LRUCache<Short, String>(MQTTProtocolConverter.DEFAULT_CACHE_SIZE);
 
-        short setPacketId(MQTTSubscription subscription, ActiveMQMessage message, PUBLISH publish) {
+        short setPacketId(MQTTSubscription subscription, ActiveMQMessage message, PUBLISH publish) throws JMSException {
             // subscription key
             final StringBuilder subscriptionKey = new StringBuilder();
             subscriptionKey.append(subscription.getConsumerInfo().getDestination().getPhysicalName())

--- a/activemq-stomp/src/main/java/org/apache/activemq/transport/stomp/FrameTranslator.java
+++ b/activemq-stomp/src/main/java/org/apache/activemq/transport/stomp/FrameTranslator.java
@@ -51,7 +51,7 @@ public interface FrameTranslator {
         private Helper() {
         }
 
-        public static void copyStandardHeadersFromMessageToFrame(ProtocolConverter converter, ActiveMQMessage message, StompFrame command, FrameTranslator ft) throws IOException {
+        public static void copyStandardHeadersFromMessageToFrame(ProtocolConverter converter, ActiveMQMessage message, StompFrame command, FrameTranslator ft) throws IOException, JMSException {
             final Map<String, String> headers = command.getHeaders();
             headers.put(Stomp.Headers.Message.DESTINATION, ft.convertDestination(converter, message.getDestination()));
             headers.put(Stomp.Headers.Message.MESSAGE_ID, message.getJMSMessageID());

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/bugs/AMQ4893Test.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/bugs/AMQ4893Test.java
@@ -72,7 +72,7 @@ public class AMQ4893Test {
         }
     }
 
-    private void fakeUnmarshal(ActiveMQObjectMessage message) throws IOException {
+    private void fakeUnmarshal(ActiveMQObjectMessage message) throws IOException, JMSException {
         // we need to force the unmarshalled property field to be set so it
         // gives us a hawtbuffer for the string
         OpenWireFormat format = new OpenWireFormat();

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/command/ActiveMQMessageTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/command/ActiveMQMessageTest.java
@@ -193,7 +193,7 @@ public class ActiveMQMessageTest extends TestCase {
         assertEquals(msg.getJMSMessageID(), this.jmsMessageID);
     }
 
-    public void testGetAndSetJMSTimestamp() {
+    public void testGetAndSetJMSTimestamp() throws JMSException {
         ActiveMQMessage msg = new ActiveMQMessage();
         msg.setJMSTimestamp(this.jmsTimestamp);
         assertTrue(msg.getJMSTimestamp() == this.jmsTimestamp);
@@ -216,7 +216,7 @@ public class ActiveMQMessageTest extends TestCase {
         assertTrue(this.jmsCorrelationID.equals(str2));
     }
 
-    public void testGetAndSetJMSCorrelationID() {
+    public void testGetAndSetJMSCorrelationID() throws JMSException {
         ActiveMQMessage msg = new ActiveMQMessage();
         msg.setJMSCorrelationID(this.jmsCorrelationID);
         assertTrue(msg.getJMSCorrelationID().equals(this.jmsCorrelationID));
@@ -234,31 +234,31 @@ public class ActiveMQMessageTest extends TestCase {
         assertTrue(msg.getJMSDestination().equals(this.jmsDestination));
     }
 
-    public void testGetAndSetJMSDeliveryMode() {
+    public void testGetAndSetJMSDeliveryMode() throws JMSException {
         ActiveMQMessage msg = new ActiveMQMessage();
         msg.setJMSDeliveryMode(this.jmsDeliveryMode);
         assertTrue(msg.getJMSDeliveryMode() == this.jmsDeliveryMode);
     }
 
-    public void testGetAndSetMSRedelivered() {
+    public void testGetAndSetMSRedelivered()throws JMSException {
         ActiveMQMessage msg = new ActiveMQMessage();
         msg.setJMSRedelivered(this.jmsRedelivered);
         assertTrue(msg.getJMSRedelivered() == this.jmsRedelivered);
     }
 
-    public void testGetAndSetJMSType() {
+    public void testGetAndSetJMSType()throws JMSException {
         ActiveMQMessage msg = new ActiveMQMessage();
         msg.setJMSType(this.jmsType);
         assertTrue(msg.getJMSType().equals(this.jmsType));
     }
 
-    public void testGetAndSetJMSExpiration() {
+    public void testGetAndSetJMSExpiration()throws JMSException {
         ActiveMQMessage msg = new ActiveMQMessage();
         msg.setJMSExpiration(this.jmsExpiration);
         assertTrue(msg.getJMSExpiration() == this.jmsExpiration);
     }
 
-    public void testGetAndSetJMSPriority() {
+    public void testGetAndSetJMSPriority() throws JMSException {
         ActiveMQMessage msg = new ActiveMQMessage();
         msg.setJMSPriority(this.jmsPriority);
         assertTrue(msg.getJMSPriority() == this.jmsPriority);
@@ -982,11 +982,261 @@ public class ActiveMQMessageTest extends TestCase {
         }
     }
 
-    public void testIsExpired() {
+    public void testIsExpired() throws JMSException {
         ActiveMQMessage msg = new ActiveMQMessage();
         msg.setJMSExpiration(System.currentTimeMillis() - 1);
         assertTrue(msg.isExpired());
         msg.setJMSExpiration(System.currentTimeMillis() + 10000);
         assertFalse(msg.isExpired());
+    }
+
+    public void testMessageGetterInaccessible() throws JMSException {
+        ActiveMQMessage msg = new ActiveMQMessage();
+        msg.setMessageAccessible(false);
+        try {
+            msg.getJMSMessageID();
+            fail("getJMSMessageID Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+        try {
+            msg.getJMSTimestamp();
+            fail("getJMSTimestamp Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+        try {
+            msg.getJMSCorrelationIDAsBytes();
+            fail("getJMSCorrelationIDAsBytes Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+        try {
+            msg.getJMSCorrelationID();
+            fail("getJMSCorrelationID Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+        try {
+            msg.getJMSReplyTo();
+            fail("getJMSReplyTo Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+        try {
+            msg.getJMSDestination();
+            fail("getJMSDestination Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+        try {
+            msg.getJMSDeliveryMode();
+            fail("getJMSDeliveryMode Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+        try {
+            msg.getJMSRedelivered();
+            fail("getJMSRedelivered Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+        try {
+            msg.getJMSType();
+            fail("getJMSType Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+        try {
+            msg.getJMSExpiration();
+            fail("getJMSExpiration Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+        try {
+            msg.getJMSPriority();
+            fail("getJMSPriority Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+        try {
+            msg.getBody(String.class);
+            fail("getBody Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+        try {
+            msg.getBooleanProperty("");
+            fail("getBooleanProperty Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+        try {
+            msg.getShortProperty("");
+            fail("getShortProperty Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+        try {
+            msg.getIntProperty("");
+            fail("getIntProperty Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+        try {
+            msg.getLongProperty("");
+            fail("getLongProperty Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+        try {
+            msg.getFloatProperty("");
+            fail("getFloatProperty Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+        try {
+            msg.getDoubleProperty("");
+            fail("getDoubleProperty Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+        try {
+            msg.getStringProperty("");
+            fail("getStringProperty Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+        try {
+            msg.getObjectProperty("");
+            fail("getObjectProperty Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+    }
+
+    public void testMessageSetterInaccessible() throws JMSException {
+        ActiveMQMessage msg = new ActiveMQMessage();
+        msg.setMessageAccessible(false);
+        try {
+            msg.setJMSMessageID("");
+            fail("getJMSMessageID Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+        try {
+            msg.setJMSTimestamp(0L);
+            fail("setJMSTimestamp Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+        try {
+            msg.setJMSCorrelationIDAsBytes(new byte[]{});
+            fail("setJMSCorrelationIDAsBytes Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+        try {
+            msg.setJMSCorrelationID("");
+            fail("setJMSCorrelationID Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+        try {
+            msg.setJMSReplyTo(null);
+            fail("setJMSReplyTo Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+        try {
+            msg.setJMSDestination(null);
+            fail("setJMSDestination Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+        try {
+            msg.setJMSDeliveryMode(0);
+            fail("setJMSDeliveryMode Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+        try {
+            msg.setJMSRedelivered(false);
+            fail("setJMSRedelivered Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+        try {
+            msg.setJMSType("");
+            fail("setJMSType Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+        try {
+            msg.setJMSExpiration(0L);
+            fail("setJMSExpiration Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+        try {
+            msg.setJMSPriority(0);
+            fail("setJMSPriority Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+        try {
+            msg.setBooleanProperty("proporty", false);
+            fail("setBooleanProperty Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+        try {
+            msg.setShortProperty("proporty", (short)0);
+            fail("setShortProperty Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+        try {
+            msg.setIntProperty("proporty", 0);
+            fail("setIntProperty Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+        try {
+            msg.setLongProperty("proporty", 0L);
+            fail("setLongProperty Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+        try {
+            msg.setFloatProperty("proporty", 0.0f);
+            fail("setFloatProperty Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+        try {
+            msg.setDoubleProperty("proporty", 0.0);
+            fail("setDoubleProperty Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+        try {
+            msg.setStringProperty("proporty", "");
+            fail("setStringProperty Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+        try {
+            msg.setObjectProperty("proporty", null);
+            fail("setObjectProperty Should have thrown exception");
+        } catch (JMSException e) {
+            checkIfMessageInaccessibleJMSExcaptionMessageMatch(e);
+        }
+    }
+
+    private void checkIfMessageInaccessibleJMSExcaptionMessageMatch(JMSException e) throws JMSException {
+        if (!e.getMessage().equals("Can not access and mutate message, the message is sent asynchronously and its completion listener has not been invoked")) {
+            throw new JMSException("JMSException error don't match");
+        }
     }
 }

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/jms2/ActiveMQJMS2AsyncSendTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/jms2/ActiveMQJMS2AsyncSendTest.java
@@ -1,0 +1,544 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.jms2;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.jms.CompletionListener;
+import jakarta.jms.Destination;
+import jakarta.jms.JMSContext;
+import jakarta.jms.JMSException;
+import jakarta.jms.JMSProducer;
+import jakarta.jms.Message;
+import jakarta.jms.MessageConsumer;
+import jakarta.jms.Session;
+import jakarta.jms.TextMessage;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ActiveMQJMS2AsyncSendTest extends ActiveMQJMS2TestBase{
+
+    private static final Logger log = LoggerFactory.getLogger(ActiveMQJMS2AsyncSendTest.class);
+
+    @Test
+    public void testSendMessageWithSessionApi_spec_7_3_1() throws Exception {
+        // https://jakarta.ee/specifications/messaging/3.1/jakarta-messaging-spec-3.1#quality-of-service
+        CountDownLatch latch = new CountDownLatch(1);
+        CompletionListener completionListener = new CompletionListener() {
+
+            @Override
+            public void onCompletion(Message message) {
+                latch.countDown();
+            }
+
+            @Override
+            public void onException(Message message, Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+
+        messageProducer.send(
+                session.createQueue(methodNameDestinationName),
+                session.createTextMessage("Test-" + methodNameDestinationName),
+                completionListener);
+        boolean status = latch.await(10L, TimeUnit.SECONDS);
+        if (!status) {
+            fail("the completion listener was not triggered within 10 seconds or threw an exception");
+        }
+    }
+
+    @Test
+    public void testSendMessageWithContextApi_spec_7_3_1() throws Exception {
+        // https://jakarta.ee/specifications/messaging/3.1/jakarta-messaging-spec-3.1#quality-of-service
+        try(JMSContext jmsContext = activemqConnectionFactory.createContext(DEFAULT_JMS_USER, DEFAULT_JMS_PASS, Session.AUTO_ACKNOWLEDGE)) {
+            assertNotNull(jmsContext);
+            JMSProducer jmsProducer = jmsContext.createProducer();
+            Destination destination = jmsContext.createQueue(methodNameDestinationName);
+            String textBody = "Test-" + methodNameDestinationName;
+            jmsContext.start();
+            CountDownLatch latch = new CountDownLatch(1);
+            CompletionListener completionListener = new CompletionListener() {
+
+                @Override
+                public void onCompletion(Message message) {
+                    latch.countDown();
+                }
+
+                @Override
+                public void onException(Message message, Exception e) {
+                    throw new RuntimeException(e);
+                }
+            };
+            jmsProducer.setAsync(completionListener);
+            jmsProducer.send(destination, textBody);
+            boolean status = latch.await(10L, TimeUnit.SECONDS);
+            if (!status) {
+                fail("the completion listener was not triggered within 10 seconds or threw an exception");
+            }
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testOnExceptionTriggered_spec_7_3_2() throws Exception {
+        // https://jakarta.ee/specifications/messaging/3.1/jakarta-messaging-spec-3.1#exceptions
+        try(JMSContext jmsContext = activemqConnectionFactory.createContext(DEFAULT_JMS_USER, DEFAULT_JMS_PASS, Session.AUTO_ACKNOWLEDGE)) {
+            assertNotNull(jmsContext);
+            JMSProducer jmsProducer = jmsContext.createProducer();
+            Destination destination = jmsContext.createQueue(methodNameDestinationName);
+            String textBody = "Test-" + methodNameDestinationName;
+            jmsContext.start();
+            CountDownLatch latch = new CountDownLatch(1);
+            CompletionListener completionListener = new CompletionListener() {
+
+                @Override
+                public void onCompletion(Message message) throws RuntimeException {
+                    throw new RuntimeException("throw runtime exception");
+                }
+
+                @Override
+                public void onException(Message message, Exception e) {
+                    latch.countDown();
+                }
+            };
+
+            jmsProducer.setAsync(completionListener);
+            jmsProducer.send(destination, textBody);
+            boolean status = latch.await(10L, TimeUnit.SECONDS);
+            if (!status) {
+                fail("the completion listener onException method was not triggered within 10 seconds");
+            }
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testCorrectMessageOrder_spec7_3_3() throws Exception {
+        // https://jakarta.ee/specifications/messaging/3.1/jakarta-messaging-spec-3.1#message-order-2
+        try(JMSContext jmsContext = activemqConnectionFactory.createContext(DEFAULT_JMS_USER, DEFAULT_JMS_PASS, Session.AUTO_ACKNOWLEDGE)) {
+            assertNotNull(jmsContext);
+            JMSProducer jmsProducer = jmsContext.createProducer();
+            Destination destination = jmsContext.createQueue(methodNameDestinationName);
+            ArrayList<String> expectedOrderedMessages = new ArrayList<>();
+            ArrayList<String> actualOrderedMessages = new ArrayList<>();
+            Object mutex = new Object();
+            jmsContext.start();
+            int num_msgs = 100;
+            CountDownLatch latch = new CountDownLatch(num_msgs);
+            CompletionListener completionListener = new CompletionListener() {
+                @Override
+                public void onCompletion(Message message) {
+                    synchronized (mutex) {
+                        try {
+                            String text = ((TextMessage) message).getText();
+                            actualOrderedMessages.add(text);
+                        } catch (JMSException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                    latch.countDown();
+                }
+
+                @Override
+                public void onException(Message message, Exception e) {
+                    throw new RuntimeException(e);
+                }
+            };
+
+            jmsProducer.setAsync(completionListener);
+            for (int i = 0; i < num_msgs; i++) {
+                String textBody = "Test-" + methodNameDestinationName + "-" + String.valueOf(i);
+                expectedOrderedMessages.add(textBody);
+                jmsProducer.send(destination, textBody);
+            }
+            boolean status = latch.await(10L, TimeUnit.SECONDS);
+            if (!status) {
+                fail("the completion listener was not triggered within 10 seconds or threw an exception");
+            }
+            for (int i = 0; i < num_msgs; i++) {
+                String got = actualOrderedMessages.get(i);
+                String expected = expectedOrderedMessages.get(i);
+                if (!got.equals(expected)) {
+                    fail(String.format("Message out of order. Got %s but expected %s", got, expected));
+                }
+            }
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testUnableToCloseContextInCompletionListener_spec_7_3_4() throws Exception {
+        // https://jakarta.ee/specifications/messaging/3.1/jakarta-messaging-spec-3.1#close-commit-or-rollback
+        try(JMSContext jmsContext = activemqConnectionFactory.createContext(DEFAULT_JMS_USER, DEFAULT_JMS_PASS, Session.AUTO_ACKNOWLEDGE)) {
+            assertNotNull(jmsContext);
+            JMSProducer jmsProducer = jmsContext.createProducer();
+            Destination destination = jmsContext.createQueue(methodNameDestinationName);
+            String textBody = "Test-" + methodNameDestinationName;
+            jmsContext.start();
+            CountDownLatch latch = new CountDownLatch(1);
+            CompletionListener completionListener = new CompletionListener() {
+
+                @Override
+                public void onCompletion(Message message) {
+                    jmsContext.close(); // This should cause a RuntimeException to throw and trigger the onException
+                }
+
+                @Override
+                public void onException(Message message, Exception e) {
+                    latch.countDown();
+                }
+            };
+
+            jmsProducer.setAsync(completionListener);
+            jmsProducer.send(destination, textBody);
+            boolean status = latch.await(10L, TimeUnit.SECONDS);
+            if (!status) {
+                fail("the completion listener onException was not triggered within 10 seconds or threw an exception");
+            }
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testUnableToCloseProducerInCompletionListener_spec_7_3_4() throws Exception {
+        // https://jakarta.ee/specifications/messaging/3.1/jakarta-messaging-spec-3.1#close-commit-or-rollback
+        CountDownLatch latch = new CountDownLatch(1);
+        CompletionListener completionListener = new CompletionListener() {
+            @Override
+            public void onCompletion(Message message) {
+                try {
+                    messageProducer.close(); // This should cause a RuntimeException to throw and trigger the onException
+                } catch (JMSException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            @Override
+            public void onException(Message message, Exception e) {
+                latch.countDown();
+            }
+        };
+        messageProducer.send(session.createQueue(methodNameDestinationName),
+                session.createTextMessage("Test-" + methodNameDestinationName), completionListener);
+        boolean status = latch.await(10L, TimeUnit.SECONDS);
+        if (!status) {
+            fail("the completion listener onException was not triggered within 10 seconds or threw an exception");
+        }
+    }
+
+    @Test
+    public void testUnableToCommitTransactionInCompletionListener_spec_7_3_4() throws Exception {
+        // https://jakarta.ee/specifications/messaging/3.1/jakarta-messaging-spec-3.1#close-commit-or-rollback
+        try(JMSContext jmsContext = activemqConnectionFactory.createContext(
+                DEFAULT_JMS_USER, DEFAULT_JMS_PASS, Session.SESSION_TRANSACTED)) {
+            assertNotNull(jmsContext);
+            JMSProducer jmsProducer = jmsContext.createProducer();
+            Destination destination = jmsContext.createQueue(methodNameDestinationName);
+            String textBody = "Test-" + methodNameDestinationName;
+            jmsContext.start();
+            CountDownLatch latch = new CountDownLatch(1);
+            CompletionListener completionListener = new CompletionListener() {
+
+                @Override
+                public void onCompletion(Message message) {
+                    jmsContext.commit(); // This should cause a RuntimeException to throw and trigger the onException
+                }
+
+                @Override
+                public void onException(Message message, Exception e) {
+                    latch.countDown();
+                }
+            };
+
+            jmsProducer.setAsync(completionListener);
+            jmsProducer.send(destination, textBody);
+            boolean status = latch.await(10L, TimeUnit.SECONDS);
+            if (!status) {
+                fail("the completion listener onException was not triggered within 10 seconds or threw an exception");
+            }
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testUnableToRollbackTransactionInCompletionListener_spec_7_3_4() throws Exception {
+        // https://jakarta.ee/specifications/messaging/3.1/jakarta-messaging-spec-3.1#close-commit-or-rollback
+        try(JMSContext jmsContext = activemqConnectionFactory.createContext(
+                DEFAULT_JMS_USER, DEFAULT_JMS_PASS, Session.SESSION_TRANSACTED)) {
+            assertNotNull(jmsContext);
+            JMSProducer jmsProducer = jmsContext.createProducer();
+            Destination destination = jmsContext.createQueue(methodNameDestinationName);
+            String textBody = "Test-" + methodNameDestinationName;
+            jmsContext.start();
+            CountDownLatch latch = new CountDownLatch(1);
+            CompletionListener completionListener = new CompletionListener() {
+
+                @Override
+                public void onCompletion(Message message) {
+                    jmsContext.rollback(); // This should cause a RuntimeException to throw and trigger the onException
+                }
+
+                @Override
+                public void onException(Message message, Exception e) {
+                    latch.countDown();
+                }
+            };
+
+            jmsProducer.setAsync(completionListener);
+            jmsProducer.send(destination, textBody);
+            boolean status = latch.await(10L, TimeUnit.SECONDS);
+            if (!status) {
+                fail("the completion listener onException was not triggered within 10 seconds or threw an exception");
+            }
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testCloseContextWailUntilAllIncompleteSentToFinish_spec_7_3_4() throws Exception {
+        // https://jakarta.ee/specifications/messaging/3.1/jakarta-messaging-spec-3.1#close-commit-or-rollback
+        try(JMSContext jmsContext = activemqConnectionFactory.createContext(DEFAULT_JMS_USER, DEFAULT_JMS_PASS, Session.AUTO_ACKNOWLEDGE)) {
+            assertNotNull(jmsContext);
+            JMSProducer jmsProducer = jmsContext.createProducer();
+            Destination destination = jmsContext.createQueue(methodNameDestinationName);
+            ArrayList<String> expectedOrderedMessages = new ArrayList<>();
+            ArrayList<String> actualOrderedMessages = new ArrayList<>();
+            Object mutex = new Object();
+            jmsContext.start();
+            int num_msgs = 100;
+            CompletionListener completionListener = new CompletionListener() {
+                @Override
+                public void onCompletion(Message message) {
+                    synchronized (mutex) {
+                        try {
+                            String text = ((TextMessage) message).getText();
+                            actualOrderedMessages.add(text);
+                        } catch (JMSException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                }
+
+                @Override
+                public void onException(Message message, Exception e) {
+                    throw new RuntimeException(e);
+                }
+            };
+
+            jmsProducer.setAsync(completionListener);
+            for (int i = 0; i < num_msgs; i++) {
+                String textBody = "Test-" + methodNameDestinationName + "-" + String.valueOf(i);
+                expectedOrderedMessages.add(textBody);
+                jmsProducer.send(destination, textBody);
+            }
+            jmsContext.close();
+            if (expectedOrderedMessages.size() != actualOrderedMessages.size()) {
+                fail("jmsContext doesn't wait until all inComplete send to finish");
+            }
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testCommitContextWailUntilAllIncompleteSentToFinish_spec_7_3_4() throws Exception {
+        // https://jakarta.ee/specifications/messaging/3.1/jakarta-messaging-spec-3.1#close-commit-or-rollback
+        try(JMSContext jmsContext = activemqConnectionFactory.createContext(DEFAULT_JMS_USER, DEFAULT_JMS_PASS, Session.SESSION_TRANSACTED)) {
+            assertNotNull(jmsContext);
+            JMSProducer jmsProducer = jmsContext.createProducer();
+            Destination destination = jmsContext.createQueue(methodNameDestinationName);
+            ArrayList<String> expectedOrderedMessages = new ArrayList<>();
+            ArrayList<String> actualOrderedMessages = new ArrayList<>();
+            Object mutex = new Object();
+            jmsContext.start();
+            int num_msgs = 100;
+            CompletionListener completionListener = new CompletionListener() {
+                @Override
+                public void onCompletion(Message message) {
+                    synchronized (mutex) {
+                        try {
+                            String text = ((TextMessage) message).getText();
+                            actualOrderedMessages.add(text);
+                        } catch (JMSException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                }
+
+                @Override
+                public void onException(Message message, Exception e) {
+                    throw new RuntimeException(e);
+                }
+            };
+
+            jmsProducer.setAsync(completionListener);
+            for (int i = 0; i < num_msgs; i++) {
+                String textBody = "Test-" + methodNameDestinationName + "-" + String.valueOf(i);
+                expectedOrderedMessages.add(textBody);
+                jmsProducer.send(destination, textBody);
+            }
+            jmsContext.commit();
+            if (expectedOrderedMessages.size() != actualOrderedMessages.size()) {
+                fail("jmsContext doesn't wait until all inComplete send to finish");
+            }
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testAbleToAccessMessageHeaderAfterAsyncSendCompleted_spec7_3_6_spec7_3_9() throws Exception {
+        // https://jakarta.ee/specifications/messaging/3.1/jakarta-messaging-spec-3.1#message-headers
+        // We won't throw exception because it's optional as stated in the spec.
+        // "If the Jakarta Messaging provider does not throw an exception then the behaviour is undefined."
+        try(JMSContext jmsContext = activemqConnectionFactory.createContext(DEFAULT_JMS_USER, DEFAULT_JMS_PASS, Session.AUTO_ACKNOWLEDGE)) {
+            assertNotNull(jmsContext);
+            JMSProducer jmsProducer = jmsContext.createProducer();
+            Destination destination = jmsContext.createQueue(methodNameDestinationName);
+            String textBody = "Test-" + methodNameDestinationName;
+            jmsContext.start();
+            CountDownLatch latch = new CountDownLatch(1);
+            CompletionListener completionListener = new CompletionListener() {
+
+                @Override
+                public void onCompletion(Message message) {
+                    try {
+                        if (!((TextMessage) message).getText().equals(textBody)) {
+                            log.error("messages don't match");
+                            throw new RuntimeException("messages don't match");
+                        }
+                    } catch (JMSException e) {
+                        throw new RuntimeException(e);
+                    }
+                    latch.countDown();
+                }
+
+                @Override
+                public void onException(Message message, Exception e) {
+                    throw new RuntimeException(e);
+                }
+            };
+            jmsProducer.setAsync(completionListener);
+            TextMessage message = jmsContext.createTextMessage();
+            message.setText(textBody);
+            jmsProducer.send(destination, message);
+            // Trying to get the message header
+            int deliveryMode = message.getJMSDeliveryMode();
+            boolean status = latch.await(10L, TimeUnit.SECONDS);
+            if (!status) {
+                fail("the completion listener was not triggered within 10 seconds or threw an exception");
+            }
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testCompletionListenerThreadingRestriction_spec7_3_7() throws Exception {
+        // (https://jakarta.ee/specifications/messaging/3.1/jakarta-messaging-spec-3.1#restrictions-on-threading)
+        // The session can continue to be used by current application thread. Session is used one thread at a time (CompletionListener, Application thread ... etc)
+        CountDownLatch latch = new CountDownLatch(1);
+        CompletionListener completionListener = new CompletionListener() {
+            @Override
+            public void onCompletion(Message message) {
+                try {
+                    // Simulate busy processing of the message for 5 seconds.
+                    Thread.sleep(5 * 1000);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                latch.countDown();
+            }
+
+            @Override
+            public void onException(Message message, Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+
+        messageProducer.send(
+                session.createQueue(methodNameDestinationName),
+                session.createTextMessage("Test-" + methodNameDestinationName),
+                completionListener);
+        MessageConsumer consumer = session.createConsumer(session.createQueue(methodNameDestinationName));
+        Message msg = consumer.receive(2 * 1000);
+        if (msg == null) {
+            fail("session in the original thread of control was dedicated to the thread of control of CompletionListener");
+        }
+        String gotTextBody = ((TextMessage) msg).getText();
+        if (!gotTextBody.equals("Test-" + methodNameDestinationName)) {
+            fail("receive message is different than the one originally sent");
+        }
+        boolean status = latch.await(10L, TimeUnit.SECONDS);
+        if (!status) {
+            fail("the completion listener was not triggered within 10 seconds or threw an exception");
+        }
+    }
+
+    @Test
+    public void testCompletionListenerInvokedInDifferentThread_spec7_3_8() throws Exception {
+        // https://jakarta.ee/specifications/messaging/3.1/jakarta-messaging-spec-3.1#use-of-the-completionlistener-by-the-jakarta-messaging-provider
+        // The CompletionListener has to be invoked in different thread
+        try(JMSContext jmsContext = activemqConnectionFactory.createContext(DEFAULT_JMS_USER, DEFAULT_JMS_PASS, Session.AUTO_ACKNOWLEDGE)) {
+            assertNotNull(jmsContext);
+            JMSProducer jmsProducer = jmsContext.createProducer();
+            Destination destination = jmsContext.createQueue(methodNameDestinationName);
+            String textBody = "Test-" + methodNameDestinationName;
+            jmsContext.start();
+            String testThreadName = Thread.currentThread().getName();
+            CountDownLatch latch = new CountDownLatch(1);
+            CompletionListener completionListener = new CompletionListener() {
+
+                @Override
+                public void onCompletion(Message message) {
+                    String onCompletionThreadName = Thread.currentThread().getName();
+                    if (!onCompletionThreadName.equals(testThreadName)) {
+                        latch.countDown();
+                    } else {
+                        log.error("onCompletion is executed in the same thread as the application thread.");
+                    }
+                }
+
+                @Override
+                public void onException(Message message, Exception e) {
+                    throw new RuntimeException(e);
+                }
+            };
+
+            jmsProducer.setAsync(completionListener);
+            jmsProducer.send(destination, textBody);
+            boolean status = latch.await(10L, TimeUnit.SECONDS);
+            if (!status) {
+                fail("the completion listener was not triggered within 10 seconds or threw an exception");
+            }
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+    }
+}

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/jms2/ActiveMQJMS2ContextTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/jms2/ActiveMQJMS2ContextTest.java
@@ -23,6 +23,8 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.Enumeration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import jakarta.jms.CompletionListener;
 import jakarta.jms.Destination;
@@ -294,26 +296,6 @@ public class ActiveMQJMS2ContextTest extends ActiveMQJMS2TestBase {
     @Test(expected = UnsupportedOperationException.class)
     public void testProducerDeliveryDelaySet() throws JMSException {
         messageProducer.setDeliveryDelay(1000l);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testProducerSendMessageCompletionListener() throws JMSException {
-         messageProducer.send(session.createQueue(methodNameDestinationName), null, (CompletionListener)null);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testProducerSendMessageQoSParamsCompletionListener() throws JMSException {
-         messageProducer.send(null, 1, 4, 0l, null);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testProducerSendDestinationMessageCompletionListener() throws JMSException {
-         messageProducer.send(session.createQueue(methodNameDestinationName), null, null);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testProducerSendDestinationMessageQosParamsCompletionListener() throws JMSException {
-         messageProducer.send(session.createQueue(methodNameDestinationName), null, 1, 4, 0l, null);
     }
 
     protected static void sendMessage(JMSContext jmsContext, Destination testDestination, String textBody) {


### PR DESCRIPTION
**What is this PR about?**
Implemented Jakarta Messaging 3.1 spec, section 7.3 https://jakarta.ee/specifications/messaging/3.1/jakarta-messaging-spec-3.1#asynchronous-send

Here an overview of how each requirement is satisfied:
**7.3.1 Quality of service**
This CR implements the feature in both Classic and Simplified API. It references implementation of synchronous send and asynchronous send. It is confirmed that the CompletionListener is triggered only when broker server returns acknowledgement.

**7.3.2 Exceptions**
I trigger CompletionListener#onException if the onComplete throws an exception.

**7.3.3 Message order**
This basically is "enforced" by the broker server. The requirement of 7.3.3 states that async messages sent to a particular destination should honor the order when it comes to execution of associated CompletionListeners. In that case, the broker server will send acknowledge the same order as the send sequence, hence the execution of CompletionListener will follow the same order. Will write a testcase for it. 

**7.3.4 Close, commit or rollback**
The wait until all incompleted async send is Implemented by a CountdownLock (I implemented it, it is similar to a CountDownLatch but it can be incremented). Before the session is dispose, it will block until CountdownLock is at zero. (If it is zero, then it is not blocked). 

I also used a ThreadLocal object to set a "marker". So if the close, rollback, commit methods are called on the session or producer in the same thread of onComplete execution, it will throw an exception.

**7.3.5 Restrictions on usage in Jakarta EE**
I don't think we need to do this. I haven't found an example of it in the codebase. Also from the spec, that is recommended but not mandatory. Asked on the dev mailing list we can skip this requirement: https://lists.apache.org/thread/r4fmmjcbgbgm0gw5mo4k3m4h3jzj8x8q

**7.3.6 Message headers**
This implementation won't throw the exception if the application try to modify or access the message before the completionListenr is completed. Here are the reasons:
1. The spec doesn't not demand the Jakarta messaging provider to throw an exception ("may"). 
2. The primary reason for not supporting it is that it is the application responsibility to honor "Applications which perform an asynchronous send must take account of the restriction that a Message object is designed to be accessed by one logical thread of control at a time and does not support concurrent use." Let's say if the application construct the `Message` interface using its own implementation (i.e not using `JMSContext#createMessage`), when it is passed to the `send` method of `JMSProducer` the provider can't augment the original object because the `jakarta.jms.Message` doesn't expose a method to do so.  

Note: I explored setting a flag in `ActiveMQMessage` to make it throw exception when properties or headers are accessed. However, it kind of violates the message object "one logical thread of control at a time" restriction and need to throw JMSException and propagate out (messy code). I decide to not implement the suggestion as it's not required by the spec.

**7.3.7 Restrictions on threading**
The execution of CompletionListener is in the transport layer (in another thread). The application thread can continue to use the session after performing an asynchronous send.

**7.3.8 Use of the CompletionListener by the Jakarta Messaging provider**
The execution of CompletionListener is in the transport layer (in another thread)

**7.3.9 Restrictions on the use of the Message object**
See explanation at 7.3.6.

**How do I test this change**
1. I wrote unit tests.
2. I did many manual tests with a broker that simulates delay in sending back ack. I used it to test multiple scenario including message orders are honored according to 7.3.3, 7.3.7.